### PR TITLE
[FIXED JENKINS-26452] Prevent NPE if no publisher in conditional step.

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -198,6 +198,7 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
             // This can happen if the projects publisher list was removed, returning
             // a list with one null element.
             if (publisherList.contains(null)) {
+                publisherList = new ArrayList<BuildStep>(publisherList);
                 publisherList.remove(null);
             }
         }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -111,6 +111,10 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     public ConditionalPublisher(final RunCondition condition, final List<BuildStep> publisherList, final BuildStepRunner runner,
             boolean configuredAggregation, final RunCondition aggregationCondition, final BuildStepRunner aggregationRunner) {
         this.condition = condition;
+        // Guard against inserting null publishers to the list.
+        if (publisherList == null || publisherList.contains(null)) {
+            throw new IllegalArgumentException("Must specifiy a publisher for a conditional publisher.");
+        }
         this.publisherList = publisherList;
         this.runner = runner;
         if (configuredAggregation) {
@@ -137,9 +141,19 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     }
 
     public List<BuildStep> getPublisherList() {
-        return publisherList != null?publisherList:Collections.<BuildStep>emptyList();
-    }
+        if (publisherList != null) {
+            // We also need to guard against any null values in the publisherList
+            // This can happen if the projects publisher list was removed, returning
+            // a list with one null element.
+            if (publisherList.contains(null)) {
+                publisherList.remove(null);
+            }
 
+            return publisherList;
+        } else {
+            return Collections.<BuildStep>emptyList();
+        }
+    }
     public BuildStepRunner getRunner() {
         return runner;
     }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -111,10 +111,6 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     public ConditionalPublisher(final RunCondition condition, final List<BuildStep> publisherList, final BuildStepRunner runner,
             boolean configuredAggregation, final RunCondition aggregationCondition, final BuildStepRunner aggregationRunner) {
         this.condition = condition;
-        // Guard against inserting null publishers to the list.
-        if (publisherList == null || publisherList.contains(null)) {
-            throw new IllegalArgumentException("Must specifiy a publisher for a conditional publisher.");
-        }
         this.publisherList = publisherList;
         this.runner = runner;
         if (configuredAggregation) {
@@ -293,7 +289,9 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
                 if (a != null && !a.isEmpty()) {
                     publisherList = new ArrayList<BuildStep>(a.size());
                     for(int idx = 0; idx < a.size(); ++idx) {
-                        publisherList.add(bindJSONWithDescriptor(req, a.getJSONObject(idx), "publisherList"));
+                        BuildStep buildstep = bindJSONWithDescriptor(req, a.getJSONObject(idx), "publisherList");
+                        if (buildstep != null)
+                            publisherList.add(buildstep);
                     }
                 }
             }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -137,8 +137,9 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     }
 
     public List<BuildStep> getPublisherList() {
-        return publisherList !=null?publisherList:Collections.<BuildStep>emptyList();
+        return publisherList != null?publisherList:Collections.<BuildStep>emptyList();
     }
+
     public BuildStepRunner getRunner() {
         return runner;
     }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -137,18 +137,7 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     }
 
     public List<BuildStep> getPublisherList() {
-        if (publisherList != null) {
-            // We also need to guard against any null values in the publisherList
-            // This can happen if the projects publisher list was removed, returning
-            // a list with one null element.
-            if (publisherList.contains(null)) {
-                publisherList.remove(null);
-            }
-
-            return publisherList;
-        } else {
-            return Collections.<BuildStep>emptyList();
-        }
+        return publisherList !=null?publisherList:Collections.<BuildStep>emptyList();
     }
     public BuildStepRunner getRunner() {
         return runner;
@@ -203,6 +192,16 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
             publisherList.add(publisher);
             publisher = null;
         }
+        
+        if (publisherList != null) {
+            // We also need to guard against any null values in the publisherList
+            // This can happen if the projects publisher list was removed, returning
+            // a list with one null element.
+            if (publisherList.contains(null)) {
+                publisherList.remove(null);
+            }
+        }
+        
         if (runner == null)
             runner = new BuildStepRunner.Fail();
         return this;

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
@@ -202,7 +202,7 @@ public class ConfigurationTest extends HudsonTestCase {
                 Arrays.<BuildStep>asList(
                         new BuildTrigger("anotherProject1", Result.SUCCESS),
                         new BuildTrigger("anotherProject2", Result.UNSTABLE)
-                ), 
+                ),
                 new BuildStepRunner.Run(), 
                 false,
                 null,
@@ -265,7 +265,7 @@ public class ConfigurationTest extends HudsonTestCase {
         assertEquals(Arrays.<Class<?>>asList(
                     ArtifactArchiver.class,
                     ArtifactArchiver.class
-            ),
+            ), 
             Lists.transform(conditionalPublisher2.getPublisherList(), new Function<BuildStep, Class<?>>() {
                 @Override
                 public Class<?> apply(BuildStep input) {

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
@@ -27,6 +27,7 @@ package org.jenkins_ci.plugins.flexible_publish;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import hudson.Launcher;
@@ -53,6 +54,7 @@ import hudson.util.DescribableList;
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
 import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
 import org.jenkins_ci.plugins.run_condition.core.NeverRun;
+import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -87,6 +89,21 @@ public class ConfigurationTest extends HudsonTestCase {
         reconfigure(p);
     }
     
+    @Bug(19985)
+    public void testNullCondition() throws  Exception {
+      FreeStyleProject p = createFreeStyleProject();
+      try {
+        ConditionalPublisher conditionalPublisher = new ConditionalPublisher(new AlwaysRun(),
+                Collections.<BuildStep>singletonList(null),
+                null,
+                false,
+                null,
+                null);
+
+          fail("Should throw Exception when null publishers are added.");
+      } catch (IllegalArgumentException e) { }
+    }
+  
     public void testSingleCondition() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         BuildTrigger trigger = new BuildTrigger("anotherProject", Result.SUCCESS);

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
@@ -202,7 +202,7 @@ public class ConfigurationTest extends HudsonTestCase {
                 Arrays.<BuildStep>asList(
                         new BuildTrigger("anotherProject1", Result.SUCCESS),
                         new BuildTrigger("anotherProject2", Result.UNSTABLE)
-                ),
+                ), 
                 new BuildStepRunner.Run(), 
                 false,
                 null,

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/ConfigurationTest.java
@@ -237,12 +237,12 @@ public class ConfigurationTest extends HudsonTestCase {
         assertEquals(Arrays.<Class<?>>asList(
                         BuildTrigger.class,
                         BuildTrigger.class
-                ),
+                ), 
                 Lists.transform(conditionalPublisher1.getPublisherList(), new Function<BuildStep, Class<?>>() {
-                  @Override
-                  public Class<?> apply(BuildStep input) {
-                    return input.getClass();
-                  }
+                    @Override
+                    public Class<?> apply(BuildStep input) {
+                        return input.getClass();
+                    }
                 })
         );
         {
@@ -263,15 +263,15 @@ public class ConfigurationTest extends HudsonTestCase {
         assertNull(conditionalPublisher2.getAggregationCondition());
         assertNull(conditionalPublisher2.getAggregationRunner());
         assertEquals(Arrays.<Class<?>>asList(
-                        ArtifactArchiver.class,
-                        ArtifactArchiver.class
-                ),
-                Lists.transform(conditionalPublisher2.getPublisherList(), new Function<BuildStep, Class<?>>() {
-                  @Override
-                  public Class<?> apply(BuildStep input) {
+                    ArtifactArchiver.class,
+                    ArtifactArchiver.class
+            ),
+            Lists.transform(conditionalPublisher2.getPublisherList(), new Function<BuildStep, Class<?>>() {
+                @Override
+                public Class<?> apply(BuildStep input) {
                     return input.getClass();
-                  }
-                })
+                }
+            })
         );
         {
             ArtifactArchiver archiver = (ArtifactArchiver)conditionalPublisher2.getPublisherList().get(0);
@@ -410,7 +410,7 @@ public class ConfigurationTest extends HudsonTestCase {
         assertEquals(1, inputList.size());
         
         // Enable it!
-        assertTrue(((HtmlCheckBoxInput) inputList.get(0)).isChecked());
+        assertTrue(((HtmlCheckBoxInput)inputList.get(0)).isChecked());
         ((HtmlCheckBoxInput)inputList.get(0)).click();
         assertFalse(((HtmlCheckBoxInput)inputList.get(0)).isChecked());
         submit(configForm);


### PR DESCRIPTION
[JENKINS-26452](https://issues.jenkins-ci.org/browse/JENKINS-26452)

If there are no publishers added to the flexible publish plugin, then the plugin can throw a NPE when saving, executing a build, and restarting Jenkins will fail to load the job.

@reviewbybees