### PR TITLE
[JENKINS-26936] demonstrates abort exception stacktrace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <!-- DependencyGraph is final in Jenkins < 1.425 -->
-        <version>1.425</version>
+        <version>1.598</version>
     </parent>
 
     <artifactId>flexible-publish</artifactId>
@@ -68,6 +68,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>run-condition</artifactId>
             <version>0.7</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>matrix-project</artifactId>
+          <version>1.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
@@ -112,10 +112,11 @@ public class FlexiblePublisher extends Recorder implements DependecyDeclarer, Ma
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
                                                                                                 throws InterruptedException, IOException {
+        boolean wholeResult = true;
         for (ConditionalPublisher publisher : publishers)
             if (!publisher.perform(build, launcher, listener))
-                setResult(build, Result.FAILURE);
-        return true;
+                wholeResult = false;
+        return wholeResult;
     }
 
     private static void setResult(final AbstractBuild<?, ?> build, final Result result) {

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
@@ -277,7 +277,7 @@ public class FlexiblePublisherTest extends HudsonTestCase {
             p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
             
             FreeStyleBuild b = p.scheduleBuild2(0).get();
-            assertBuildStatus(Result.FAILURE, b);
+            assertBuildStatus(Result.SUCCESS, b);
             
             // ArtifactArchiver is executed even prior publisher fails.
             assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
@@ -25,20 +25,33 @@
 package org.jenkins_ci.plugins.flexible_publish;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
 import hudson.tasks.ArtifactArchiver;
 
 import org.jenkins_ci.plugins.flexible_publish.testutils.FileWriteBuilder;
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
 import org.jenkins_ci.plugins.run_condition.core.StringsMatchCondition;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -156,6 +169,324 @@ public class FlexiblePublisherTest extends HudsonTestCase {
             assertFalse(new File(b.getArtifactsDir(), "artifact2.txt").exists());
             assertFalse(new File(b.getArtifactsDir(), "artifact3.txt").exists());
             assertFalse(new File(b.getArtifactsDir(), "artifact4.txt").exists());
+        }
+    }
+    
+    public static class FailurePublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            return false;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "FailurePublisher";
+            }
+        }
+    }
+    
+    public static class ThorwAbortExceptionPublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            throw new AbortException("Intended abort");
+            //return true;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "ThorwAbortExceptionPublisher";
+            }
+        }
+    }
+    
+    public static class ThorwGeneralExceptionPublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            throw new IOException("Intended abort");
+            //return true;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "ThorwGeneralExceptionPublisher";
+            }
+        }
+    }
+    
+    public void testRunAllPublishers() throws Exception {
+        // Jenkins executes all publishers even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FailurePublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Jenkins executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new ThorwAbortExceptionPublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+            
+            // Somehow Jenkins prints stacktrace for AbortException. You can see that here.
+            // System.out.println(b.getLog());
+        }
+        
+        // Jenkins executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new ThorwGeneralExceptionPublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        //// Flexible Publish should run as Jenkins core do.
+        
+        // Flexible Publish executes all publishers even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new FailurePublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwAbortExceptionPublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwGeneralExceptionPublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        
+        //// Of course, ConditionalPublisher should do so.
+        
+        // Flexible Publish executes all publishers in a condition even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new FailurePublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwAbortExceptionPublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwGeneralExceptionPublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
         }
     }
 }


### PR DESCRIPTION
This demonstrates Jennkins 1.598 (the current latest) prints a stacktrace for AbortException in free style projects.