### PR TITLE
[JENKINS-27278] Execution strategy for publishers in a condition

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexibleMatrixAggregator.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexibleMatrixAggregator.java
@@ -32,6 +32,7 @@ import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixRun;
 import hudson.model.BuildListener;
+import hudson.model.Result;
 
 /**
  * {@link MatrixAggregator} for {@link FlexiblePublisher}.
@@ -105,6 +106,7 @@ public class FlexibleMatrixAggregator extends MatrixAggregator {
                 }
             } catch (Exception e) {
                 e.printStackTrace(listener.error(String.format("[flexible-publish] aggregation with %s is aborted due to exception", cma.toString())));
+                build.setResult(Result.FAILURE);
                 wholeResult = false;
             }
         }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexibleMatrixAggregator.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexibleMatrixAggregator.java
@@ -96,11 +96,18 @@ public class FlexibleMatrixAggregator extends MatrixAggregator {
      */
     @Override
     public boolean endBuild() throws InterruptedException, IOException {
+        boolean wholeResult = true;
         for (ConditionalMatrixAggregator cma: aggregatorList) {
-            if (!cma.endBuild()) {
-                return false;
+            try {
+                if (!cma.endBuild()) {
+                    listener.error(String.format("[flexible-publish] aggregation with %s failed", cma.toString()));
+                    wholeResult = false;
+                }
+            } catch (Exception e) {
+                e.printStackTrace(listener.error(String.format("[flexible-publish] aggregation with %s is aborted due to exception", cma.toString())));
+                wholeResult = false;
             }
         }
-        return true;
+        return wholeResult;
     }
 }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
@@ -112,10 +112,11 @@ public class FlexiblePublisher extends Recorder implements DependecyDeclarer, Ma
     @Override
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
                                                                                                 throws InterruptedException, IOException {
+        boolean wholeResult = true;
         for (ConditionalPublisher publisher : publishers)
             if (!publisher.perform(build, launcher, listener))
-                setResult(build, Result.FAILURE);
-        return true;
+                wholeResult = false;
+        return wholeResult;
     }
 
     private static void setResult(final AbstractBuild<?, ?> build, final Result result) {

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
@@ -318,4 +318,12 @@ public class FlexiblePublisher extends Recorder implements DependecyDeclarer, Ma
                 build, launcher, listener, aggregatorList
         );
     }
+    
+    protected static String getBuildStepName(BuildStep s) {
+        if (s instanceof Describable) {
+            return String.format("%s (%s)", ((Describable<?>)s).getDescriptor().getDisplayName(), s.toString());
+        } else {
+            return s.toString();
+        }
+    }
 }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
@@ -115,9 +115,24 @@ public class FlexiblePublisher extends Recorder implements DependecyDeclarer, Ma
     public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
                                                                                                 throws InterruptedException, IOException {
         boolean wholeResult = true;
-        for (ConditionalPublisher publisher : publishers)
-            if (!publisher.perform(build, launcher, listener))
+        for (ConditionalPublisher publisher : publishers) {
+            try {
+                if (!publisher.perform(build, launcher, listener))
+                {
+                    // error logs should be printed in ConditionalPublisher (or ConditionalExecutionStrategy)
+                    wholeResult = false;
+                }
+            } catch(Exception e) {
+                // This code doesn't run
+                // as Exceptions should be handled in ConditionalPublisher (or ConditionalExecutionStrategy)
+                e.printStackTrace(listener.error(String.format(
+                        "[flexible-publish] %s aborted due to exception",
+                        FlexiblePublisher.getBuildStepShortName(publisher.getPublisherList())
+                )));
+                build.setResult(Result.FAILURE);
                 wholeResult = false;
+            }
+        }
         return wholeResult;
     }
 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/RunAllBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/RunAllBuilder.java
@@ -1,0 +1,175 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.flexible_publish;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import hudson.Launcher;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Builder;
+
+/**
+ * Used with {@link BuildStepRunner}.
+ * 
+ * Run all build steps.
+ */
+/*package*/ class RunAllBuilder extends Builder {
+    private final List<BuildStep> buildsteps;
+    
+    public RunAllBuilder(List<BuildStep> buildsteps) {
+        this.buildsteps = buildsteps;
+    }
+    /**
+     * Run {@link BuildStep#prebuild(AbstractBuild, BuildListener)} of all build steps.
+     * 
+     * Doesn't run following build steps when a build step fails.
+     * 
+     * @param build
+     * @param listener
+     * @return
+     * @see hudson.tasks.BuildStep#prebuild(hudson.model.AbstractBuild, hudson.model.BuildListener)
+     */
+    @Override
+    public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
+        for (BuildStep buildstep: buildsteps) {
+            if (!buildstep.prebuild(build, listener)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Run {@link BuildStep#prebuild(AbstractBuild, BuildListener)} of all build steps.
+     * 
+     * Runs following build steps even when a build step fails.
+     * 
+     * @param build
+     * @param launcher
+     * @param listener
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     * @see hudson.tasks.BuildStep#perform(hudson.model.AbstractBuild, hudson.Launcher, hudson.model.BuildListener)
+     */
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        // do as AbstractBuild.AbstractRunner#performAllBuildSteps
+        boolean wholeResult = true;
+        for (BuildStep buildstep: buildsteps) {
+            try {
+                if (!buildstep.perform(build, launcher, listener)) {
+                    listener.error(String.format(
+                            "[flexible-publish] %s failed",
+                            FlexiblePublisher.getBuildStepName(buildstep)
+                    ));
+                    build.setResult(Result.FAILURE);
+                    wholeResult = false;
+                }
+            } catch (Exception e) {
+                e.printStackTrace(listener.error(String.format(
+                        "[flexible-publish] %s aborted due to exception",
+                        FlexiblePublisher.getBuildStepName(buildstep)
+                )));
+                build.setResult(Result.FAILURE);
+                wholeResult = false;
+            }
+        }
+        return wholeResult;
+    }
+    
+    @Override
+    public Descriptor<Builder> getDescriptor() {
+        return new Descriptor<Builder>() {
+            @Override
+            public String getDisplayName() {
+                return String.format("[%s]", StringUtils.join(
+                        Lists.transform(
+                                buildsteps,
+                                new Function<BuildStep, String>() {
+                                    @Override
+                                    public String apply(BuildStep input) {
+                                        if (input instanceof Describable) {
+                                            return ((Describable<?>)input).getDescriptor().getDisplayName();
+                                        }
+                                        return input.getClass().getName();
+                                    }
+                                }
+                        ),
+                        ", "
+                ));
+            }
+        };
+    }
+    
+    /**
+     * Not Supported
+     * 
+     * @param project
+     * @return
+     * @deprecated
+     * @see hudson.tasks.BuildStep#getProjectAction(hudson.model.AbstractProject)
+     */
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> project) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @param project
+     * @return
+     * @see hudson.tasks.BuildStep#getProjectActions(hudson.model.AbstractProject)
+     */
+    @Override
+    public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @return
+     * @see hudson.tasks.BuildStep#getRequiredMonitorService()
+     */
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        throw new UnsupportedOperationException();
+    }
+    
+}

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
@@ -22,13 +22,14 @@
  * THE SOFTWARE.
  */
 
-package org.jenkins_ci.plugins.flexible_publish;
+package org.jenkins_ci.plugins.flexible_publish.builder;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkins_ci.plugins.flexible_publish.FlexiblePublisher;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
@@ -50,10 +51,10 @@ import hudson.tasks.Builder;
  * 
  * Run all build steps.
  */
-/*package*/ class RunAllBuilder extends Builder {
+public class FailAtEndBuilder extends Builder {
     private final List<BuildStep> buildsteps;
     
-    public RunAllBuilder(List<BuildStep> buildsteps) {
+    public FailAtEndBuilder(List<BuildStep> buildsteps) {
         this.buildsteps = buildsteps;
     }
     /**
@@ -99,7 +100,7 @@ import hudson.tasks.Builder;
                 if (!buildstep.perform(build, launcher, listener)) {
                     listener.error(String.format(
                             "[flexible-publish] %s failed",
-                            FlexiblePublisher.getBuildStepName(buildstep)
+                            FlexiblePublisher.getBuildStepDetailedName(buildstep)
                     ));
                     build.setResult(Result.FAILURE);
                     wholeResult = false;
@@ -107,7 +108,7 @@ import hudson.tasks.Builder;
             } catch (Exception e) {
                 e.printStackTrace(listener.error(String.format(
                         "[flexible-publish] %s aborted due to exception",
-                        FlexiblePublisher.getBuildStepName(buildstep)
+                        FlexiblePublisher.getBuildStepDetailedName(buildstep)
                 )));
                 build.setResult(Result.FAILURE);
                 wholeResult = false;

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
@@ -1,0 +1,178 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.flexible_publish.builder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkins_ci.plugins.flexible_publish.FlexiblePublisher;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import hudson.Launcher;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Builder;
+
+/**
+ * Used with {@link BuildStepRunner}.
+ * 
+ * Run build steps, but stops execution immediately when any of them fail.
+ */
+public class FailFastBuilder extends Builder {
+    private final List<BuildStep> buildsteps;
+    
+    public FailFastBuilder(List<BuildStep> buildsteps) {
+        this.buildsteps = buildsteps;
+    }
+    /**
+     * Run {@link BuildStep#prebuild(AbstractBuild, BuildListener)} of all build steps.
+     * 
+     * Doesn't run following build steps when a build step fails.
+     * 
+     * @param build
+     * @param listener
+     * @return
+     * @see hudson.tasks.BuildStep#prebuild(hudson.model.AbstractBuild, hudson.model.BuildListener)
+     */
+    @Override
+    public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
+        for (BuildStep buildstep: buildsteps) {
+            if (!buildstep.prebuild(build, listener)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Run {@link BuildStep#prebuild(AbstractBuild, BuildListener)} of all build steps.
+     * 
+     * Runs following build steps even when a build step fails.
+     * 
+     * @param build
+     * @param launcher
+     * @param listener
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     * @see hudson.tasks.BuildStep#perform(hudson.model.AbstractBuild, hudson.Launcher, hudson.model.BuildListener)
+     */
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        for (BuildStep buildstep: buildsteps) {
+            try {
+                if (!buildstep.perform(build, launcher, listener)) {
+                    listener.error(String.format(
+                            "[flexible-publish] %s failed",
+                            FlexiblePublisher.getBuildStepDetailedName(buildstep)
+                    ));
+                    build.setResult(Result.FAILURE);
+                    return false;
+                }
+            } catch (Exception e) {
+                listener.error(String.format(
+                        "[flexible-publish] %s failed due to exception",
+                        FlexiblePublisher.getBuildStepDetailedName(buildstep)
+                ));
+                e.printStackTrace(listener.error(String.format(
+                        "[flexible-publish] %s aborted due to exception",
+                        FlexiblePublisher.getBuildStepDetailedName(buildstep)
+                )));
+                build.setResult(Result.FAILURE);
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public Descriptor<Builder> getDescriptor() {
+        return new Descriptor<Builder>() {
+            @Override
+            public String getDisplayName() {
+                return String.format("[%s]", StringUtils.join(
+                        Lists.transform(
+                                buildsteps,
+                                new Function<BuildStep, String>() {
+                                    @Override
+                                    public String apply(BuildStep input) {
+                                        if (input instanceof Describable) {
+                                            return ((Describable<?>)input).getDescriptor().getDisplayName();
+                                        }
+                                        return input.getClass().getName();
+                                    }
+                                }
+                        ),
+                        ", "
+                ));
+            }
+        };
+    }
+    
+    /**
+     * Not Supported
+     * 
+     * @param project
+     * @return
+     * @deprecated
+     * @see hudson.tasks.BuildStep#getProjectAction(hudson.model.AbstractProject)
+     */
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> project) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @param project
+     * @return
+     * @see hudson.tasks.BuildStep#getProjectActions(hudson.model.AbstractProject)
+     */
+    @Override
+    public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+        throw new UnsupportedOperationException();
+    }
+    
+    /**
+     * @return
+     * @see hudson.tasks.BuildStep#getRequiredMonitorService()
+     */
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        throw new UnsupportedOperationException();
+    }
+    
+}

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/MarkPerformedBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/MarkPerformedBuilder.java
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-package org.jenkins_ci.plugins.flexible_publish;
+package org.jenkins_ci.plugins.flexible_publish.builder;
 
 import java.io.IOException;
 
@@ -39,7 +39,7 @@ import hudson.tasks.Builder;
  * 
  * Stores whether perform is executed.
  */
-class MarkPerformedBuilder extends Builder {
+public class MarkPerformedBuilder extends Builder {
     private boolean performed = false;
     
     public boolean isPerformed() {

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/ConditionalExecutionStrategy.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/ConditionalExecutionStrategy.java
@@ -32,7 +32,6 @@ import jenkins.model.Jenkins;
 import org.jenkins_ci.plugins.flexible_publish.ConditionalPublisher;
 import org.jenkins_ci.plugins.run_condition.RunCondition;
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
-import org.jenkins_ci.plugins.run_condition.BuildStepRunner.BuildStepRunnerDescriptor;
 
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
@@ -44,7 +43,6 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.tasks.BuildStep;
 
 /**
@@ -55,7 +53,7 @@ public abstract class ConditionalExecutionStrategy
         implements ExtensionPoint
 {
     /**
-     * Carries parameters from {@link ConditionalPublisher}
+     * Carries parameters from {@link ConditionalPublisher} to run publishers.
      * This allows us keep compatibility when introducing new parameters.
      */
     public static class PublisherContext {
@@ -82,6 +80,10 @@ public abstract class ConditionalExecutionStrategy
         }
     }
     
+    /**
+     * Carries parameters from {@link ConditionalPublisher} to run aggregators.
+     * This allows us keep compatibility when introducing new parameters.
+     */
     public static class AggregatorContext {
         private final MatrixBuild build;
         private final Launcher launcher;
@@ -126,14 +128,58 @@ public abstract class ConditionalExecutionStrategy
         }
     }
     
+    /**
+     * Run {@link BuildStep#prebuild(AbstractBuild, BuildListener)} for all publishers.
+     * 
+     * @param context
+     * @param build
+     * @param listener
+     * @return false to abort the build.
+     */
     public abstract boolean prebuild(PublisherContext context, AbstractBuild<?,?> build, BuildListener listener);
     
+    /**
+     * Run {@link BuildStep#perform(AbstractBuild, Launcher, BuildListener)} for all publishes.
+     * 
+     * @param context
+     * @param build
+     * @param launcher
+     * @param listener
+     * @return false to indicate a failure. That doesn't abort the build.
+     * @throws InterruptedException
+     * @throws IOException
+     */
     public abstract boolean perform(PublisherContext context, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException;
     
+    /**
+     * Run {@link MatrixAggregator#startBuild()} for all publishes.
+     * 
+     * @param aggregatorContext
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     */
     public abstract boolean matrixAggregationStartBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException;
     
+    /**
+     * Run {@link MatrixAggregator#endRun(MatrixRun)} for all publishes.
+     * 
+     * @param aggregatorContext
+     * @param run
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     */
     public abstract boolean matrixAggregationEndRun(AggregatorContext aggregatorContext, MatrixRun run) throws InterruptedException, IOException;
     
+    /**
+     * Run {@link MatrixAggregator#endBuild()} for all publishes.
+     * 
+     * @param aggregatorContext
+     * @return
+     * @throws InterruptedException
+     * @throws IOException
+     */
     public abstract boolean matrixAggregationEndBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException;
     
     public static DescriptorExtensionList<ConditionalExecutionStrategy, Descriptor<ConditionalExecutionStrategy>> all() {

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/ConditionalExecutionStrategy.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/ConditionalExecutionStrategy.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.flexible_publish.strategy;
+
+import java.io.IOException;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
+import org.jenkins_ci.plugins.flexible_publish.ConditionalPublisher;
+import org.jenkins_ci.plugins.run_condition.RunCondition;
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner.BuildStepRunnerDescriptor;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixRun;
+import hudson.matrix.MatrixBuild;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.tasks.BuildStep;
+
+/**
+ * A base class for a strategy for how to run publishers in a condition
+ */
+public abstract class ConditionalExecutionStrategy
+        extends AbstractDescribableImpl<ConditionalExecutionStrategy>
+        implements ExtensionPoint
+{
+    /**
+     * Carries parameters from {@link ConditionalPublisher}
+     * This allows us keep compatibility when introducing new parameters.
+     */
+    public static class PublisherContext {
+        private final BuildStepRunner runner;
+        private final RunCondition condition;
+        private final List<BuildStep> publisherList;
+        
+        public PublisherContext(BuildStepRunner runner, RunCondition condition, List<BuildStep> publisherList) {
+            this.runner = runner;
+            this.condition = condition;
+            this.publisherList = publisherList;
+        }
+        
+        public BuildStepRunner getRunner() {
+            return runner;
+        }
+        
+        public RunCondition getCondition() {
+            return condition;
+        }
+        
+        public List<BuildStep> getPublisherList() {
+            return publisherList;
+        }
+    }
+    
+    public static class AggregatorContext {
+        private final MatrixBuild build;
+        private final Launcher launcher;
+        private final BuildListener listener;
+        private final BuildStepRunner runner;
+        private final RunCondition condition;
+        private final List<MatrixAggregator> aggregatorList;
+        
+        public AggregatorContext(MatrixBuild build, Launcher launcher, BuildListener listener, 
+                BuildStepRunner runner, RunCondition condition, List<MatrixAggregator> aggregatorList
+        ) {
+            this.build = build;
+            this.launcher = launcher;
+            this.listener = listener;
+            this.runner = runner;
+            this.condition = condition;
+            this.aggregatorList = aggregatorList;
+        }
+        
+        public MatrixBuild getBuild() {
+            return build;
+        }
+        
+        public Launcher getLauncher() {
+            return launcher;
+        }
+        
+        public BuildListener getListener() {
+            return listener;
+        }
+        
+        public BuildStepRunner getRunner() {
+            return runner;
+        }
+        
+        public RunCondition getCondition() {
+            return condition;
+        }
+        
+        public List<MatrixAggregator> getAggregatorList() {
+            return aggregatorList;
+        }
+    }
+    
+    public abstract boolean prebuild(PublisherContext context, AbstractBuild<?,?> build, BuildListener listener);
+    
+    public abstract boolean perform(PublisherContext context, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException;
+    
+    public abstract boolean matrixAggregationStartBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException;
+    
+    public abstract boolean matrixAggregationEndRun(AggregatorContext aggregatorContext, MatrixRun run) throws InterruptedException, IOException;
+    
+    public abstract boolean matrixAggregationEndBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException;
+    
+    public static DescriptorExtensionList<ConditionalExecutionStrategy, Descriptor<ConditionalExecutionStrategy>> all() {
+        return Jenkins.getInstance().getDescriptorList(ConditionalExecutionStrategy.class);
+    }
+
+}

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.flexible_publish.strategy;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixRun;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+
+import java.io.IOException;
+
+import org.jenkins_ci.plugins.flexible_publish.builder.FailAtEndBuilder;
+import org.jenkins_ci.plugins.flexible_publish.builder.MarkPerformedBuilder;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Run all publishers even some of them fail.
+ * To be exact, work as Jenkins core does:
+ * <table>
+ *   <tr>
+ *     <th>prebuild</th>
+ *     <td>fail fast</td>
+ *   </tr>
+ *   <tr>
+ *     <th>perform</th>
+ *     <td>fail at end</td>
+ *   </tr>
+ *   <tr>
+ *     <th>aggregation startBuild</th>
+ *     <td>fail fast</td>
+ *   </tr>
+ *   <tr>
+ *     <th>aggregation endRun</th>
+ *     <td>fail fast</td>
+ *   </tr>
+ *   <tr>
+ *     <th>aggregation endBuild</th>
+ *     <td>fail at end</td>
+ *   </tr>
+ * </table>
+ */
+public class FailAtEndExecutionStrategy extends ConditionalExecutionStrategy {
+    @DataBoundConstructor
+    public FailAtEndExecutionStrategy() {
+    }
+    
+    @Override
+    public boolean prebuild(PublisherContext context, AbstractBuild<?, ?> build, BuildListener listener) {
+        return context.getRunner().prebuild(
+                context.getCondition(),
+                new FailAtEndBuilder(context.getPublisherList()),
+                build, listener
+        );
+    }
+    
+    @Override
+    public boolean perform(PublisherContext context, AbstractBuild<?, ?> build,
+            Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        return context.getRunner().perform(
+                context.getCondition(),
+                new FailAtEndBuilder(context.getPublisherList()),
+                build, launcher, listener
+        );
+    }
+    
+    @Override
+    public boolean matrixAggregationStartBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException {
+        for(MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            if (!aggregator.startBuild()) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public boolean matrixAggregationEndRun(
+            AggregatorContext aggregatorContext, MatrixRun run) throws InterruptedException, IOException
+    {
+        MarkPerformedBuilder mpb = new MarkPerformedBuilder();
+        boolean isSuccess = aggregatorContext.getRunner().perform(
+                aggregatorContext.getCondition(),
+                mpb,
+                run, // watch out! not parent build.
+                aggregatorContext.getLauncher(),
+                aggregatorContext.getListener()
+        );
+        
+        if(!isSuccess || !mpb.isPerformed()) {
+            return isSuccess;
+        }
+        
+        for (MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            if (!aggregator.endRun(run)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public boolean matrixAggregationEndBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException {
+        boolean wholeResult = true;
+        for(MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            try {
+                if (!aggregator.endBuild()) {
+                    aggregatorContext.getListener().error(String.format("[flexible-publish] aggregation with %s failed", aggregator.toString()));
+                    wholeResult = false;
+                }
+            } catch (Exception e) {
+                e.printStackTrace(aggregatorContext.getListener().error(String.format("[flexible-publish] aggregation with %s is aborted due to exception", aggregator.toString())));
+                aggregatorContext.getBuild().setResult(Result.FAILURE);
+                wholeResult = false;
+            }
+        }
+        return wholeResult;
+    }
+    
+    @Extension(ordinal=100)    // this is the default strategy >= 0.15
+    public static class DescriptorImpl extends Descriptor<ConditionalExecutionStrategy> {
+        @Override
+        public String getDisplayName() {
+            return Messages.FailAtEndExecutionStragery_DisplayName();
+        }
+        
+    }
+}

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailFastExecutionStrategy.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailFastExecutionStrategy.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.flexible_publish.strategy;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixRun;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+
+import java.io.IOException;
+
+import org.jenkins_ci.plugins.flexible_publish.builder.FailFastBuilder;
+import org.jenkins_ci.plugins.flexible_publish.builder.MarkPerformedBuilder;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Stop running publishers immediately when one of them fail.
+ * Following publishers aren't performed.
+ */
+public class FailFastExecutionStrategy extends ConditionalExecutionStrategy {
+    @DataBoundConstructor
+    public FailFastExecutionStrategy() {
+    }
+    
+    @Override
+    public boolean prebuild(PublisherContext context, AbstractBuild<?, ?> build, BuildListener listener) {
+        return context.getRunner().prebuild(
+                context.getCondition(),
+                new FailFastBuilder(context.getPublisherList()),
+                build, listener
+        );
+    }
+    
+    @Override
+    public boolean perform(PublisherContext context, AbstractBuild<?, ?> build,
+            Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        return context.getRunner().perform(
+                context.getCondition(),
+                new FailFastBuilder(context.getPublisherList()),
+                build, launcher, listener
+        );
+    }
+    
+    @Override
+    public boolean matrixAggregationStartBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException {
+        for(MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            if (!aggregator.startBuild()) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public boolean matrixAggregationEndRun(
+            AggregatorContext aggregatorContext, MatrixRun run) throws InterruptedException, IOException
+    {
+        MarkPerformedBuilder mpb = new MarkPerformedBuilder();
+        boolean isSuccess = aggregatorContext.getRunner().perform(
+                aggregatorContext.getCondition(),
+                mpb,
+                run, // watch out! not parent build.
+                aggregatorContext.getLauncher(),
+                aggregatorContext.getListener()
+        );
+        
+        if(!isSuccess || !mpb.isPerformed()) {
+            return isSuccess;
+        }
+        
+        for (MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            if (!aggregator.endRun(run)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public boolean matrixAggregationEndBuild(AggregatorContext aggregatorContext) throws InterruptedException, IOException {
+        for(MatrixAggregator aggregator: aggregatorContext.getAggregatorList()) {
+            try {
+                if (!aggregator.endBuild()) {
+                    aggregatorContext.getListener().error(String.format("[flexible-publish] aggregation with %s failed", aggregator.toString()));
+                    return false;
+                }
+            } catch (Exception e) {
+                e.printStackTrace(aggregatorContext.getListener().error(String.format("[flexible-publish] aggregation with %s is aborted due to exception", aggregator.toString())));
+                aggregatorContext.getBuild().setResult(Result.FAILURE);
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ConditionalExecutionStrategy> {
+        @Override
+        public String getDisplayName() {
+            return Messages.FailFastExecutionStragery_DisplayName();
+        }
+        
+    }
+}

--- a/src/main/resources/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher/config.jelly
+++ b/src/main/resources/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher/config.jelly
@@ -35,6 +35,7 @@
     <f:advanced>
     <f:dropdownDescriptorSelector title="${%runner}" field="runner" descriptors="${descriptor.buildStepRunners}"
             default="${descriptor.defaultBuildStepRunner}"/>
+    <f:dropdownDescriptorSelector title="${%Execution Strategy}" field="executionStrategy" descriptors="${descriptor.executionStrategies}" />
     </f:advanced>
     <j:if test="${descriptor.isMatrixProject(it)}">
       <f:optionalBlock inline="true" field="configuredAggregation" title="${%configureForParent}" checked="${instance.configuredForMatrixParent}">

--- a/src/main/resources/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher/help-executionStrategy.html
+++ b/src/main/resources/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher/help-executionStrategy.html
@@ -1,0 +1,16 @@
+<div>
+Defines how flexible-publish handles errors of publishers in this condition.
+Built-in strategies:
+<dl>
+  <dt>Fail at end</dt>
+    <dd>
+      Performs all publishers even some of them fail.
+      This is the behavior same to Jenkins core.
+    </dd>
+  <dt>Fail fast</dt>
+    <dd>
+      Stop performing following publishers if a publisher fails.
+      This was the behavior in Flexible publish 0.14.1 and prior.
+    </dd>
+</dl>
+</div>

--- a/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy/config.jelly
+++ b/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2015 IKEDA Yasuyuki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<!-- No fields to configure-->
+</j:jelly>

--- a/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/FailFastExecutionStrategy/config.jelly
+++ b/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/FailFastExecutionStrategy/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2015 IKEDA Yasuyuki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<!-- No fields to configure-->
+</j:jelly>

--- a/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/Messages.properties
+++ b/src/main/resources/org/jenkins_ci/plugins/flexible_publish/strategy/Messages.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2015 IKEDA Yasuyuki
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FailAtEndExecutionStragery.DisplayName=Fail at end
+FailFastExecutionStragery.DisplayName=Fail fast

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
@@ -49,6 +49,7 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.tasks.ArtifactArchiver;
 
+import org.jenkins_ci.plugins.flexible_publish.strategy.FailFastExecutionStrategy;
 import org.jenkins_ci.plugins.flexible_publish.testutils.FileWriteBuilder;
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
 import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
@@ -96,6 +97,17 @@ public class FlexiblePublisherTest extends HudsonTestCase {
             assertBuildStatusSuccess(b);
             assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
         }
+    }
+    
+    @LocalData
+    public void testMigrationFrom0_14_1() throws Exception {
+        FreeStyleProject p = jenkins.getItemByFullName("migration_from_0.14.1", FreeStyleProject.class);
+        FlexiblePublisher fp = p.getPublishersList().get(FlexiblePublisher.class);
+        ConditionalPublisher cp = fp.getPublishers().get(0);
+        assertEquals(
+                FailFastExecutionStrategy.class,
+                cp.getExecutionStrategy().getClass()
+        );
     }
     
     public void testMultipleConditionsMultipleActions() throws Exception {

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
@@ -198,7 +198,7 @@ public class FlexiblePublisherTest extends HudsonTestCase {
         }
     }
     
-    public static class ThorwAbortExceptionPublisher extends Recorder {
+    public static class ThrowAbortExceptionPublisher extends Recorder {
         @Override
         public BuildStepMonitor getRequiredMonitorService() {
             return BuildStepMonitor.BUILD;
@@ -273,7 +273,7 @@ public class FlexiblePublisherTest extends HudsonTestCase {
             FreeStyleProject p = createFreeStyleProject();
             
             p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
-            p.getPublishersList().add(new ThorwAbortExceptionPublisher());
+            p.getPublishersList().add(new ThrowAbortExceptionPublisher());
             p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
             
             FreeStyleBuild b = p.scheduleBuild2(0).get();
@@ -347,7 +347,7 @@ public class FlexiblePublisherTest extends HudsonTestCase {
                     new ConditionalPublisher(
                             new AlwaysRun(),
                             Arrays.<BuildStep>asList(
-                                    new ThorwAbortExceptionPublisher()
+                                    new ThrowAbortExceptionPublisher()
                             ),
                             new BuildStepRunner.Fail(),
                             false,
@@ -446,7 +446,7 @@ public class FlexiblePublisherTest extends HudsonTestCase {
                     new ConditionalPublisher(
                             new AlwaysRun(),
                             Arrays.<BuildStep>asList(
-                                    new ThorwAbortExceptionPublisher(),
+                                    new ThrowAbortExceptionPublisher(),
                                     new ArtifactArchiver("**/*", "", false)
                             ),
                             new BuildStepRunner.Fail(),

--- a/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest.java
@@ -25,20 +25,33 @@
 package org.jenkins_ci.plugins.flexible_publish;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
 import hudson.tasks.ArtifactArchiver;
 
 import org.jenkins_ci.plugins.flexible_publish.testutils.FileWriteBuilder;
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
 import org.jenkins_ci.plugins.run_condition.core.StringsMatchCondition;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -156,6 +169,324 @@ public class FlexiblePublisherTest extends HudsonTestCase {
             assertFalse(new File(b.getArtifactsDir(), "artifact2.txt").exists());
             assertFalse(new File(b.getArtifactsDir(), "artifact3.txt").exists());
             assertFalse(new File(b.getArtifactsDir(), "artifact4.txt").exists());
+        }
+    }
+    
+    public static class FailurePublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            return false;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "FailurePublisher";
+            }
+        }
+    }
+    
+    public static class ThorwAbortExceptionPublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            throw new AbortException("Intended abort");
+            //return true;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "ThorwAbortExceptionPublisher";
+            }
+        }
+    }
+    
+    public static class ThorwGeneralExceptionPublisher extends Recorder {
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.BUILD;
+        }
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            throw new IOException("Intended abort");
+            //return true;
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+            
+            @Override
+            public String getDisplayName() {
+                return "ThorwGeneralExceptionPublisher";
+            }
+        }
+    }
+    
+    public void testRunAllPublishers() throws Exception {
+        // Jenkins executes all publishers even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FailurePublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Jenkins executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new ThorwAbortExceptionPublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+            
+            // Somehow Jenkins prints stacktrace for AbortException. You can see that here.
+            // System.out.println(b.getLog());
+        }
+        
+        // Jenkins executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new ThorwGeneralExceptionPublisher());
+            p.getPublishersList().add(new ArtifactArchiver("**/*", "", false));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        //// Flexible Publish should run as Jenkins core do.
+        
+        // Flexible Publish executes all publishers even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new FailurePublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwAbortExceptionPublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwGeneralExceptionPublisher()
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    ),
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        
+        //// Of course, ConditionalPublisher should do so.
+        
+        // Flexible Publish executes all publishers in a condition even one of them failed.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new FailurePublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws AbortException.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwAbortExceptionPublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
+        }
+        
+        // Flexible Publish executes all publishers even one of them throws any Exceptions.
+        {
+            FreeStyleProject p = createFreeStyleProject();
+            
+            p.getBuildersList().add(new FileWriteBuilder("artifact.txt", "blahblahblah"));
+            p.getPublishersList().add(new FlexiblePublisher(Arrays.asList(
+                    new ConditionalPublisher(
+                            new AlwaysRun(),
+                            Arrays.<BuildStep>asList(
+                                    new ThorwGeneralExceptionPublisher(),
+                                    new ArtifactArchiver("**/*", "", false)
+                            ),
+                            new BuildStepRunner.Fail(),
+                            false,
+                            null,
+                            null
+                    )
+            )));
+            
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            assertBuildStatus(Result.FAILURE, b);
+            
+            // ArtifactArchiver is executed even prior publisher fails.
+            assertTrue(new File(b.getArtifactsDir(), "artifact.txt").exists());
         }
     }
 }

--- a/src/test/resources/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest/testMigrationFrom0_14_1/config.xml
+++ b/src/test/resources/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest/testMigrationFrom0_14_1/config.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <version>1.425</version>
+</hudson>

--- a/src/test/resources/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest/testMigrationFrom0_14_1/jobs/migration_from_0.14.1/config.xml
+++ b/src/test/resources/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisherTest/testMigrationFrom0_14_1/jobs/migration_from_0.14.1/config.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers>
+    <org.jenkins__ci.plugins.flexible__publish.FlexiblePublisher>
+      <publishers>
+        <org.jenkins__ci.plugins.flexible__publish.ConditionalPublisher>
+          <condition class="org.jenkins_ci.plugins.run_condition.core.AlwaysRun"/>
+          <publisherList>
+            <hudson.tasks.ArtifactArchiver>
+              <artifacts>**/*</artifacts>
+              <latestOnly>false</latestOnly>
+            </hudson.tasks.ArtifactArchiver>
+          </publisherList>
+          <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail"/>
+        </org.jenkins__ci.plugins.flexible__publish.ConditionalPublisher>
+      </publishers>
+    </org.jenkins__ci.plugins.flexible__publish.FlexiblePublisher>
+  </publishers>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
### Overview

This introduces "execution strategy" feature to Flexible Publish plugin. It controls whether to continue to following publishers.
* They are located in the "Advanced..." section of each Conditional actions.
    ![executionstrategy1](https://cloud.githubusercontent.com/assets/3115961/6650167/465824ae-ca47-11e4-9311-f6776001b9b0.png)
* You can select "Fail at end" or "Fail fast"
    ![executionstrategy2](https://cloud.githubusercontent.com/assets/3115961/6650168/4c77b336-ca47-11e4-9b59-835afcd49354.png)

| Strategy  | Behavior on a failure of a publisher                                                                 |
|:---------:|:-----------------------------------------------------------------------------------------------------|
|Fail at end|Continues to run following publishers. The default behavior in flexible-publish 0.15 and later.           |
|Fail fast  |Doesn't run following publishers. The default behavior for flexible-publish configured in 0.13 and 0.14.1. |

This request includes following 2 changes:
1. Makes it clear how flexible-publish works when some of publishers fail.
2. Evaluates a condition only once for publishers.

They are fixes or improvements for "multiple publishers in a condition" feature I introduced in flexible-publush 0.13 (released Nov, 2014).

What I want to be reviewed:
* Aren't there unexpected regressions?
* Comments for this new feature.

### Makes it clear how flexible-publish works when some of publishers fail.

Flexible publish allows define multiple conditions and multiple publishers for each condition like this:
```
Flexible publish
    Condition 1
        Publisher 1
        Publisher 2
    Condition 2
        Publisher 3
```

There was no clear definition how flexible-publish behaves when a publisher fails.
Indeed, it works as following. For comparison, I also write the behavier of free style projects.

|Failure Type                      |Flexible publish|Condition                            |Free style project|
|:---------------------------------|:---------------|:------------------------------------|:-----------------|
|Publisher returns `false`         |Continue        |Stop (and go to the next condition)  |Continue          |
|Publisher throws `AbortException` |Stop            |Stop (whole flexible publish)        |Continue          |
|Publisher throws other `Exception`|Stop            |Stop (whole flexible publish)        |Continue          |

For example, when "Publisher 1" above returns false, "Publisher 2" doesn't run and "Publisher 3" runs.
This may be hard for users to know how flexible-publish works when a publisher fails.

The behavior of a free style project is defined in following codes:
* `hudson.model.Build.BuildExecution#post2`
* `hudson.model.AbstractBuild#performAllBuildStep`

I conclude that publishers are expected to run even a prior publisher fails:
* Publishers often send notifications of build results. Users expects notifications even some publishers fail.
* Those classes are thought to be common basic classes for projects with publishers.

For the backward compatibility, I introduced the execution strategy feature.
This request makes flexible-publish work like this:

|Failure Type                      |Flexible publish|Condition (fail at end)|Condition (fail fast)              |
|:---------------------------------|:---------------|:----------------------|:----------------------------------|
|Publisher returns `false`         |Continue        |Continue               |Stop (and go to the next condition)|
|Publisher throws `AbortException` |Continue        |Continue               |Stop (and go to the next condition)|
|Publisher throws other `Exception`|Continue        |Continue               |Stop (and go to the next condition)|


### Evaluates a condition only once for publishers

This configuration
```
Flexible publish
    Condition 1
        Publisher 1
        Publisher 2
```

works like this in flexible-publish 0.14.1 and earlier.
```
if(Condition 1){ Publisher 1 }
if(Condition 1){ Publisher 2 }
```

This request makes it works like this:
```
if(Condition 1){
  Publisher 1
  Publisher 2
}
```

Reasons:
* Users can expect the condition evaluated only once like they see in the configuration page.
* There may be conditions take much time to be evaluated or have side-effects. It's not reasonable to evaluate those conditions each time.
* If a user really want a condition evaluated for each publishers, they can do that as following:
```
Flexible publish
    Condition 1
        Publisher 1
    Condition 1
        Publisher 2
```