### PR TITLE
[JENKINS-28585] Skips aggregation processing if no publisher supports aggregation.

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -207,26 +207,26 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
     }
 
     public ConditionalMatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
-        if (isConfiguredAggregation()) {
-            // alerts if all publishers doesn't support aggregation
-            // even if configured for aggregation
-            boolean supportAggregation = false;
-            
-            for (BuildStep publisher: getPublisherList()) {
-                if (publisher instanceof MatrixAggregatable) {
-                    supportAggregation = true;
-                    break;
-                }
+        boolean supportAggregation = false;
+        
+        for (BuildStep publisher: getPublisherList()) {
+            if (publisher instanceof MatrixAggregatable) {
+                supportAggregation = true;
+                break;
             }
-            
-            if (!supportAggregation) {
+        }
+        
+        if (!supportAggregation) {
+            if (isConfiguredAggregation()) {
+                // alerts if all publishers doesn't support aggregation
+                // even if configured for aggregation
                 listener.getLogger().println(String.format(
                         "[%s] WARNING: Condition for Matrix Aggregation is configured for %s which does not support aggregation",
                         getDescriptor().getDisplayName(),
                         FlexiblePublisher.getBuildStepShortName(getPublisherList())
                 ));
-                return null;
             }
+            return null;
         }
         // First, decide whether the condition is satisfied
         // in the parent scope.


### PR DESCRIPTION
[JENKINS-28585](https://issues.jenkins-ci.org/browse/JENKINS-28585)

Regression in 0.15, which gets to evaluate the condition only once for aggregations in a condition.
It is implemented like this:
```
class ConditionalPublisher {
    public ConditionalMatrixAggregator createAggregator() {
        if(condition is satisfied) {
            if(no publisher supporting aggregation) {
                return null;
            }
            return aggregator created from publishers supporting aggregation.
        }
        return null;
    }
}
```

In that code, the condition is evaluated even if no publisher supports aggregation.
Making things worse, axes are not defined in matrix parent builds, and that often results in failures of evaluation of conditions.

I changed the implementation like this:
```
class ConditionalPublisher {
    public ConditionalMatrixAggregator createAggregator() {
        if(no publisher supporting aggregation) {
            return null;
        }
        if(condition is satisfied) {
            return aggregator created from publishers supporting aggregation.
        }
        return null;
    }
}
```