### PR TITLE
[JENKINS-64534] Fix javadoc issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Change log
 
-## 0.16
+## 0.16.1
 
 Release date: Jan 02, 2021
 
 -   FIXED: Configuration UI is broken with Jenkins 2.264+
     ([JENKINS-64478](https://issues.jenkins.io/browse/JENKINS-64478))
 -   Targets Jenkins 2.235.5+ (was 1.425+).
+-   Note: flexible-publish-0.16 is not released for javadoc issue
+    ([JENKINS-64534](https://issues.jenkins.io/browse/JENKINS-64534))
 
 
 ## 0.15.2

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/ConditionalPublisher.java
@@ -354,7 +354,7 @@ public class ConditionalPublisher implements Describable<ConditionalPublisher>, 
          * and {@link DataBoundConstructor} of classes of posted objects.
          * 
          * But we have to use {@link Descriptor#newInstance(StaplerRequest, JSONObject)}
-         * for classes without {@link DataBoundConstructor} (such as {@link hudson.tasks.Mailer})
+         * for classes without {@link DataBoundConstructor} (such as old versions of hudson.tasks.Mailer)
          * and classes with {@link Descriptor#newInstance(StaplerRequest, JSONObject)}
          * doing different from their constructors with {@link DataBoundConstructor}
          * (such as {@link hudson.tasks.junit.JUnitResultArchiver}).

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/FlexiblePublisher.java
@@ -224,7 +224,7 @@ public class FlexiblePublisher extends Recorder implements DependencyDeclarer, M
          * and {@link DataBoundConstructor} of classes of posted objects.
          * 
          * But we have to use {@link Descriptor#newInstance(StaplerRequest, JSONObject)}
-         * for classes without {@link DataBoundConstructor} (such as {@link hudson.tasks.Mailer})
+         * for classes without {@link DataBoundConstructor} (such as old versions of hudson.tasks.Mailer)
          * and classes with {@link Descriptor#newInstance(StaplerRequest, JSONObject)}
          * doing different from their constructors with {@link DataBoundConstructor}
          * (such as {@link hudson.tasks.junit.JUnitResultArchiver}).

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
@@ -49,6 +49,8 @@ import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+
 /**
  * Used with {@link BuildStepRunner}.
  * 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
@@ -49,6 +49,8 @@ import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+
 /**
  * Used with {@link BuildStepRunner}.
  * 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/MarkPerformedBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/MarkPerformedBuilder.java
@@ -34,6 +34,8 @@ import hudson.model.Descriptor;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+
 /**
  * Used with {@link BuildStepRunner}.
  * 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/strategy/FailAtEndExecutionStrategy.java
@@ -43,6 +43,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * Run all publishers even some of them fail.
  * To be exact, work as Jenkins core does:
  * <table>
+ *   <caption>Build phases and behaviors</caption>
  *   <tr>
  *     <th>prebuild</th>
  *     <td>fail fast</td>


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-64534

Failed to release flexible-publish-0.16 for javadoc issues.
This pull request fixes that and prepares flexible-publish-0.16.1.
