### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
-
-
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.78</version>
+        <version>5.28</version>
     </parent>
 
     <artifactId>flexible-publish</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <id>bap</id>
-            <name>Bap</name>
-            <email>bap-jenkins@BapIT.co.uk</email>
-        </developer>
-        <developer>
-          <id>ikedam</id>
-          <name>IKEDA Yasuyuki</name>
-        </developer>
-    </developers>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <scm>
         <url>https://github.com/jenkinsci/flexible-publish-plugin</url>
-        <connection>scm:git:git://github.com/jenkinsci/flexible-publish-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/flexible-publish-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/flexible-publish-plugin.git</developerConnection>
       <tag>HEAD</tag>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,7 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/flexible-publish-plugin.git</developerConnection>
       <tag>HEAD</tag>
   </scm>
-    
-    <issueManagement>
-        <system>Jira</system>
-        <url>http://issues.jenkins-ci.org/</url>
-    </issueManagement>
-    
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,11 @@
     <url>https://github.com/jenkinsci/flexible-publish-plugin</url>
 
     <properties>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <hpi.compatibleSinceVersion>0.15</hpi.compatibleSinceVersion>
     </properties>
-    
+
     <licenses>
         <license>
             <name>The MIT license</name>
@@ -54,8 +55,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2143.ve4c3c9ec790a</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>5804.v80587a_38d937</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -75,7 +76,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>run-condition</artifactId>
-            <version>1.5</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailAtEndBuilder.java
@@ -165,6 +165,7 @@ public class FailAtEndBuilder extends Builder {
      * @see hudson.tasks.BuildStep#getProjectAction(hudson.model.AbstractProject)
      */
     @Override
+    @Deprecated
     public Action getProjectAction(AbstractProject<?, ?> project) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/flexible_publish/builder/FailFastBuilder.java
@@ -167,6 +167,7 @@ public class FailFastBuilder extends Builder {
      * @see hudson.tasks.BuildStep#getProjectAction(hudson.model.AbstractProject)
      */
     @Override
+    @Deprecated
     public Action getProjectAction(AbstractProject<?, ?> project) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  Jenkins core has supported Java 25 since Jenkins 2.534, Oct 28, 2025.

Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

Does not compile or test with Java 17 any longer because we have found no issues in the past that were specific to the Java 17 compiler.  The plan is to drop support for Java 17 in the not too distant future so that the Jenkins project is only supporting two major Java versions at a time, Java 21 and Java 25.

Also includes changes needed to support Java 25 compile and test and modernize the plugin:

- Remove the obsolete developers section from pom
- Use https instead of git protocol in SCM connection URL
- Remove outdated issue tracking URL
- Annotate deprecated methods
- Add newline to end of pom file
- Require Jenkins 2.504.3 or newer
- Use parent pom 5.28

### Testing done

* Confirmed that automated tests pass with Java 25

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
